### PR TITLE
Fixed getFnType logic

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,10 +9,11 @@ function isGeneratorFunction(thing) {
 }
 
 const getFnType = (thing) => typeof thing === 'function' && ({
-    GeneratorFunction: 'generator',
-    AsyncFunction: 'async',
-    Function: 'plain'
-})[thing.constructor.name];
+    '[object GeneratorFunction]': 'generator',
+    '[object AsyncFunction]': 'async',
+    '[object Function]': 'plain'
+})[Object.prototype.toString.call(thing)];
+
 
 function isGenerator(thing) {
     return thing && typeof thing === 'object' && typeof thing.next === 'function';


### PR DESCRIPTION
issues: [function constructor name changed after bundled as a library #6841](https://github.com/webpack/webpack/issues/6841)

In a Webpack + Babel environment, the construct name is replaced with any character.
I found that the function passed to Promisy as a parameter does not properly check the function type.
So I modified the `getFnType`  function as below.

Please check it. :)